### PR TITLE
Add tox support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+black==19.3b0
+flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+minversion = 1.4.2
+envlist = linters
+skipsdist = True
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+
+[testenv:black]
+install_command = pip install {opts} {packages}
+commands =
+  black -v -l79 {toxinidir}
+
+[testenv:linters]
+install_command = pip install {opts} {packages}
+commands =
+  black -v -l79 --check {toxinidir}
+  flake8 {posargs}
+
+[testenv:venv]
+commands = {posargs}
+
+[flake8]
+# E123, E125 skipped as they are invalid PEP-8.
+
+show-source = True
+ignore = E123,E125
+builtins = _
+exclude = .git,.tox,tests/unit/compat/


### PR DESCRIPTION
We run these jobs in Zuul. For now, add these entrypoints until a time
we can refactor.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>